### PR TITLE
restore to normal tokenlization when validation

### DIFF
--- a/thumt/bin/trainer.py
+++ b/thumt/bin/trainer.py
@@ -100,6 +100,7 @@ def default_parameters():
         references=[""],
         save_checkpoint_secs=0,
         save_checkpoint_steps=1000,
+        restore_bpe = False,
         # Setting this to True can save disk spaces, but cannot restore
         # training using the saved checkpoint
         only_save_trainable=False
@@ -442,7 +443,8 @@ def main(args):
                     config,
                     params.keep_top_checkpoint_max,
                     eval_secs=params.eval_secs,
-                    eval_steps=params.eval_steps
+                    eval_steps=params.eval_steps,
+                    restore_bpe = params.restore_bpe
                 )
             )
 


### PR DESCRIPTION
When the [BPE](https://github.com/rsennrich/subword-nmt) is used to preprocess the corpus, our model only can be validated on the dataset processed by BPE, which is not the same as the real testing, namely testing BLEU after restoring BPE to normal tokenlization. Besides, in the experiments, I found using BPE restored validation may be better.

In this pull request, I add a new param called `restore_bpe`. When it is set to be `True`, `decoded_symbols`  in `EvaluationHook` will be restored to the normal tokenlization. And the default value of `restore_bpe` is false, which would not affect the original implementation.